### PR TITLE
Resolved an bug where temperature would output as 1200+ C

### DIFF
--- a/libHumidity/src/Hts221.cpp
+++ b/libHumidity/src/Hts221.cpp
@@ -174,7 +174,7 @@ bool Hts221::readTempRegs(float & degC)
         return false;
     }
 
-    uint16_t T_OUT = ((tempOutH << 8) | tempOutL);
+    int16_t T_OUT = ((tempOutH << 8) | tempOutL);
 
     degC = (float)_T0_DEGC_X8 / 8.0 + (T_OUT - _T0_out) * (_T1_DEGC_X8 - _T0_DEGC_X8) / 8.0 / (_T1_out - _T0_out);
     return true;


### PR DESCRIPTION
Temperature registers were read into a uint16 value and when the value was a negative it would wrap around and happened to show 1200+ degrees C. This commit resolves the issue by changing uint16 to int16.

Note: this doesn't resolve the random 1200 C values we saw when it was in the PE room but it should work for negative C values now.